### PR TITLE
deal with bad pin/channel correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,10 @@ var gpio = require('rpi-gpio');
 
 gpio.setup(7, gpio.DIR_IN, readInput);
 
-function readInput() {
+function readInput(err) {
+    if (err) {
+        throw err;
+    }
     gpio.read(7, function(err, value) {
         console.log('The value is ' + value);
     });
@@ -101,7 +104,10 @@ var gpio = require('rpi-gpio');
 
 gpio.setup(7, gpio.DIR_OUT, write);
 
-function write() {
+function write(err) {
+    if (err) {
+        throw err;
+    }
     gpio.write(7, true, function(err) {
         if (err) throw err;
         console.log('Written to pin');

--- a/rpi-gpio.js
+++ b/rpi-gpio.js
@@ -293,7 +293,10 @@ function Gpio() {
     };
 
     function getPinRpi(channel) {
-        return currentPins[channel] + '';
+        var pin = currentPins[channel];
+        if (pin) {
+            return pin + '';
+        }
     };
 
     function getPinBcm(channel) {


### PR DESCRIPTION
getPinRpi returns the string "undefined" rather than the actual value undefined if the channel is bad. async.waterfall during setup thus never sees the error, leading to a confused state.

I've update the README documentation to see the error also, as entering bad channels is unfortunately a likely very common situation.
