### PR TITLE
Add 'low' & 'high' options for the gpio direction setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Please note that there are two different and confusing ways to reference a chann
 #### setup(channel [, direction, edge], callback)
 Sets up a channel for read or write. Must be done before the channel can be used.
 * channel: Reference to the pin in the current mode's schema.
-* direction: The pin direction, pass either DIR_IN for read mode or DIR_OUT for write mode. You can also pass DIR_LOW or DIR_HIGH to use write mode with a specific initial "hot" state. Defaults to DIR_OUT.
+* direction: The pin direction, pass either DIR_IN for read mode or DIR_OUT for write mode. You can also pass DIR_LOW or DIR_HIGH to use the write mode and specify an initial state of 'off' or 'on' respectively. Defaults to DIR_OUT.
 * edge: Interrupt generating GPIO chip setting, pass in EDGE_NONE for no interrupts, EDGE_RISING for interrupts on rising values, EDGE_FALLING for interrupts on falling values or EDGE_BOTH for all interrupts.
 Defaults to EDGE_NONE.
 * callback: Provides Error as the first argument if an error occurred.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Please note that there are two different and confusing ways to reference a chann
 #### setup(channel [, direction, edge], callback)
 Sets up a channel for read or write. Must be done before the channel can be used.
 * channel: Reference to the pin in the current mode's schema.
-* direction: The pin direction, pass either DIR_IN for read mode or DIR_OUT for write mode. Defaults to DIR_OUT.
+* direction: The pin direction, pass either DIR_IN for read mode or DIR_OUT for write mode. You can also pass DIR_LOW or DIR_HIGH to use write mode with a specific initial "hot" state. Defaults to DIR_OUT.
 * edge: Interrupt generating GPIO chip setting, pass in EDGE_NONE for no interrupts, EDGE_RISING for interrupts on rising values, EDGE_FALLING for interrupts on falling values or EDGE_BOTH for all interrupts.
 Defaults to EDGE_NONE.
 * callback: Provides Error as the first argument if an error occurred.
@@ -97,6 +97,23 @@ gpio.setup(7, gpio.DIR_OUT, write);
 
 function write() {
     gpio.write(7, true, function(err) {
+        if (err) throw err;
+        console.log('Written to pin');
+    });
+}
+```
+
+### Setup and write to a pin that starts as on
+This example shows how to setup the pin for write mode with the default state as
+"on". Why do this? It can sometimes be useful to reverse the default initial 
+state due to wiring or uncontrollable circumstances.
+```js
+var gpio = require('rpi-gpio');
+
+gpio.setup(7, gpio.DIR_HIGH, write);
+
+function write() {
+    gpio.write(7, false, function(err) {
         if (err) throw err;
         console.log('Written to pin');
     });

--- a/rpi-gpio.js
+++ b/rpi-gpio.js
@@ -90,6 +90,8 @@ function Gpio() {
 
     this.DIR_IN   = 'in';
     this.DIR_OUT  = 'out';
+    this.DIR_LOW  = 'low';
+    this.DIR_HIGH = 'high';
 
     this.MODE_RPI = 'mode_rpi';
     this.MODE_BCM = 'mode_bcm';
@@ -143,7 +145,7 @@ function Gpio() {
             });
         }
 
-        if (direction !== this.DIR_IN && direction !== this.DIR_OUT) {
+        if (direction !== this.DIR_IN && direction !== this.DIR_OUT && direction !== this.DIR_LOW && direction !== this.DIR_HIGH) {
             return process.nextTick(function() {
                 onSetup(new Error('Cannot set invalid direction'));
             });

--- a/test/main.js
+++ b/test/main.js
@@ -241,6 +241,30 @@ describe('rpi-gpio', function() {
                 });
             });
 
+            context('and direction is specified low-ward', function() {
+                beforeEach(function(done) {
+                    gpio.setup(7, gpio.DIR_LOW, done);
+                });
+
+                it('should set the channel direction', function() {
+                    var args = fs.writeFile.lastCall.args;
+                    assert.equal(args[0], PATH + '/gpio7/direction');
+                    assert.equal(args[1], 'low');
+                });
+            });
+
+            context('and direction is specified high-ward', function() {
+                beforeEach(function(done) {
+                    gpio.setup(7, gpio.DIR_HIGH, done);
+                });
+
+                it ('should set the channel direction', function() {
+                    var args = fs.writeFile.lastCall.args;
+                    assert.equal(args[0], PATH + '/gpio7/direction');
+                    assert.equal(args[1], 'high');
+                });
+            });
+
             var edge_modes = ['none', 'rising', 'falling', 'both']
             edge_modes.forEach(function(edge_mode) {
                 var edgeConstant = 'EDGE_' + edge_mode.toUpperCase()


### PR DESCRIPTION
This pull request is a proposed fix for issue #25 by allowing the developer to choose which state the gpio pin should be initially set to. This is especially helpful for dealing with certain hardware setups that operate in reverse logic (0 is hot, 1 is cold).

Thanks!
