### PR TITLE
address pin config race

### DIFF
--- a/rpi-gpio.js
+++ b/rpi-gpio.js
@@ -181,7 +181,7 @@ function Gpio() {
                 exportPin(pinForSetup, next);
             },
             function(next) {
-              async.retry({times: 10, interval: 100},
+              async.retry({times: 100, interval: 10},
                 function(cb){
                   setEdge(pinForSetup, edge, cb);
                 },
@@ -197,7 +197,7 @@ function Gpio() {
                     exportedOutputPins[pinForSetup] = true;
                 }
 
-                async.retry({times: 10, interval: 100},
+                async.retry({times: 100, interval: 10},
                   function(cb) {
                     setDirection(pinForSetup, direction, cb);
                   },

--- a/rpi-gpio.js
+++ b/rpi-gpio.js
@@ -181,7 +181,14 @@ function Gpio() {
                 exportPin(pinForSetup, next);
             },
             function(next) {
-                setEdge(pinForSetup, edge, next);
+              async.retry({times: 10, interval: 100},
+                function(cb){
+                  setEdge(pinForSetup, edge, cb);
+                },
+                function(err){
+                  // wrapped here because waterfall can't handle positive result
+                  next(err);
+                });
             },
             function(next) {
                 if (direction === this.DIR_IN) {
@@ -190,7 +197,14 @@ function Gpio() {
                     exportedOutputPins[pinForSetup] = true;
                 }
 
-                setDirection(pinForSetup, direction, next);
+                async.retry({times: 10, interval: 100},
+                  function(cb) {
+                    setDirection(pinForSetup, direction, cb);
+                  },
+                  function(err) {
+                    // wrapped here because waterfall can't handle positive result
+                    next(err);
+                  });
             }.bind(this),
             function(next) {
                 listen(channel, function(readChannel) {


### PR DESCRIPTION
The edge and direction are set after a pin is exported. Because ownership is set to _gpio_
asynchronously after export, immediately setting the edge and setting the direction can fail if the
user is not root.

This patch retries each operation up to 100 times at .01s intervals, resulting in a successful
pin setup for a non-root user.

