### PR TITLE
#91 Add catch for failed /proc/cpuinfo parsing in setup()

### DIFF
--- a/rpi-gpio.js
+++ b/rpi-gpio.js
@@ -363,6 +363,11 @@ function Gpio() {
 
                 // Match the last 4 digits of the number following "Revision:"
                 var match = data.match(/Revision\s*:\s*[0-9a-f]*([0-9a-f]{4})/);
+
+                if (!match) {
+                    return reject('Unable to match Revision in /proc/cpuinfo')
+                }
+
                 var revisionNumber = parseInt(match[1], 16);
                 var pinVersion = (revisionNumber < 4) ? 'v1' : 'v2';
 

--- a/test/main.js
+++ b/test/main.js
@@ -879,6 +879,24 @@ describe('rpi-gpio', function() {
                     sinon.assert.calledOnce(callback);
                 });
             });
+
+            context('when CPU revision is invalid', function () {
+                var catchCallback;
+
+                beforeEach(function (done) {
+                    catchCallback = sandbox.spy(onSetupComplete);
+                    fs.readFile.withArgs('/proc/cpuinfo').yieldsAsync(null, getCpuInfo('A Bad Revision'));
+                    function onSetupComplete() {
+                        done();
+                    }
+
+                    gpioPromise.setup(7).catch(catchCallback);
+                });
+
+                it('should catch the error successfully', function () {
+                    sinon.assert.calledOnce(catchCallback);
+                });
+            });
         });
     });
 


### PR DESCRIPTION
Adds a check that the regex on `/proc/cpuinfo` actually matches correctly, and rejects the promise if not. I've added a small unit test that passes "A Bad Revision" to `getCpuInfo` and verifies `catch` is indeed called on the promise. Not sure if this is how you'd want to test this, but, it does verify the error is correctly caught by the Promise returned.

Fixes #91