### PR TITLE
Simplify promise interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,10 +113,9 @@ This API exposes a Promises interface to the module. All of the same functions a
 The Promises interface is available in the `promise` namespace, e.g.:
 
 ```js
-var gpio = require('rpi-gpio')
-var gpiop = gpio.promise;
+var gpiop = require('rpi-gpio').promise;
 
-gpiop.setup(7, gpio.DIR_OUT)
+gpiop.setup(7, gpiop.DIR_OUT)
     .then(() => {
         return gpiop.write(7, true)
     })

--- a/rpi-gpio.js
+++ b/rpi-gpio.js
@@ -349,7 +349,7 @@ function Gpio() {
     this.reset();
 
 
-    // Private functions requring access to state
+    // Private functions requiring access to state
     function setRaspberryVersion() {
         if (currentPins) {
             return Promise.resolve();
@@ -508,6 +508,18 @@ var GPIO = new Gpio();
 
 // Promise
 GPIO.promise = {
+    DIR_IN: DIR_IN,
+    DIR_OUT: DIR_OUT,
+    DIR_LOW: DIR_LOW,
+    DIR_HIGH: DIR_HIGH,
+
+    MODE_RPI: MODE_RPI,
+    MODE_BCM: MODE_BCM,
+
+    EDGE_NONE: EDGE_NONE,
+    EDGE_RISING: EDGE_RISING,
+    EDGE_FALLING: EDGE_FALLING,
+    EDGE_BOTH: EDGE_BOTH,
 
     /**
      * @see {@link Gpio.setup}


### PR DESCRIPTION
Add the constants to the promise interface, so that only one thing is
`require`d, and removing the need to track what’s in `gpio` vs. `gpiop`.

(Hacktoberfest submission)