### PR TITLE
Expose EventEmitter methods on gpio.promise

### DIFF
--- a/rpi-gpio.js
+++ b/rpi-gpio.js
@@ -589,7 +589,6 @@ GPIO.promise = {
 
     on: GPIO.on.bind(GPIO),
     once: GPIO.once.bind(GPIO),
-    off: GPIO.off.bind(GPIO),
     addListener: GPIO.addListener.bind(GPIO),
     removeListener: GPIO.removeListener.bind(GPIO),
     removeAllListeners: GPIO.removeAllListeners.bind(GPIO),

--- a/rpi-gpio.js
+++ b/rpi-gpio.js
@@ -585,7 +585,14 @@ GPIO.promise = {
 
             GPIO.destroy(done)
         })
-    }
+    },
+
+    on: GPIO.on.bind(GPIO),
+    once: GPIO.once.bind(GPIO),
+    off: GPIO.off.bind(GPIO),
+    addListener: GPIO.addListener.bind(GPIO),
+    removeListener: GPIO.removeListener.bind(GPIO),
+    removeAllListeners: GPIO.removeAllListeners.bind(GPIO),
 };
 
 module.exports = GPIO;


### PR DESCRIPTION
The docs say:

> This API exposes a Promises interface to the module. All of the same functions are available, but do not take callbacks and instead return a Promise.

That's not quite true, because this doesn't work:

```js
const gpio = require('rpi-gpio').promise;
gpio.on('change', console.log); // TypeError: gpio.on is not a function
```

This PR fixes that in the simplest way, by just exposing all the interesting event emitter methods from GPIO on the promise object, bound back to GPIO.

These methods don't actually use promises of course, but being able to use `.promise` as a drop-in replacement is super useful imo, and from the docs above it seems like that's what you're aiming for.